### PR TITLE
Retrait du champ Siret dans le champ Service du DataJson

### DIFF
--- a/src/@types/types.ts
+++ b/src/@types/types.ts
@@ -564,7 +564,7 @@ export type Demarche = {
   pendingDeletedDossiers: DeletedDossierConnection;
   publishedRevision?: Maybe<Revision>;
   revisions: Array<Revision>;
-  service: Maybe<Service>;
+  service?: Maybe<Service>;
   /** État de la démarche. */
   state: DemarcheState;
   /** Titre de la démarche. */

--- a/src/@types/types.ts
+++ b/src/@types/types.ts
@@ -564,7 +564,7 @@ export type Demarche = {
   pendingDeletedDossiers: DeletedDossierConnection;
   publishedRevision?: Maybe<Revision>;
   revisions: Array<Revision>;
-  service?: Maybe<Service>;
+  service: Maybe<Service>;
   /** État de la démarche. */
   state: DemarcheState;
   /** Titre de la démarche. */

--- a/src/graphql/getDemarche.ts
+++ b/src/graphql/getDemarche.ts
@@ -43,7 +43,6 @@ export default gql`
         id
         nom
         organisme
-        siret
         typeOrganisme
       }
     }

--- a/src/graphql/getDemarche.ts
+++ b/src/graphql/getDemarche.ts
@@ -43,6 +43,7 @@ export default gql`
         id
         nom
         organisme
+        siret
         typeOrganisme
       }
     }


### PR DESCRIPTION
Modifications pour rendre le champ service du DataJson généré par l'API DS-Client non-obligatoire, et supprimer le champ siret de service. 