### PR TITLE
fix: __typename is now inside custom-champ

### DIFF
--- a/src/dossier/custom-champ.type.ts
+++ b/src/dossier/custom-champ.type.ts
@@ -1,4 +1,4 @@
-import { Champ, ChampDescriptor, Dossier } from "../@types/generated-types";
+import { Champ, ChampDescriptor, Dossier } from "../@types/types";
 
 export type CustomChamp = Champ & {
   champDescriptor: ChampDescriptor;


### PR DESCRIPTION
Biblionum could not access __typename of customChamp like it could for Champ because CustomChamp was taking Champ type from wrong place.